### PR TITLE
Fix big-endian binary instruction decode

### DIFF
--- a/data/languages/mb.sinc
+++ b/data/languages/mb.sinc
@@ -41,8 +41,6 @@ define context imm_contextreg
 @define MSR_C     "msr[29,1]"
 @define MSR_IE    "msr[30,1]"
 
-@if ENDIAN == "little"
-
 define token instr(32)
       op05 = (26,31)
       op610 = (21,25)
@@ -70,40 +68,6 @@ define token instr(32)
       imm15= (0,14)
       fsl = (0,3)
 ;
-
-@else # ENDIAN == "big"
-define token instr(32)
-      op05 = (0,5)
-      op610 = (6,10)
-      op2131 = (21,31)
-      op1620 = (16,20)
-      op1631 = (16,31)
-      op1617 = (16,17)
-      op1115 = (11,15)
-      op1116 = (11,16)
-      op2626 = (26,26)
-      op2126 = (21,26)
-      op1627 = (16,27)
-
-      rD = (6,10)
-      rA = (11,15)
-      rB = (16,20)
-      rA_zero = (11,15)
-      rB_zero = (16,20)
-      rS = (21,31)
-      imm = (16,31)
-      
-      immw = (21,25)
-      imms = (27,31) 
-      imm3 = (6,10)
-      imm14= (18,31)
-      imm15= (17,31)
-      fsl = (28,31)
-;
-
-@endif # ENDIAN = "big"
-
-
 
 
 attach variables [ rD rA rB ] [ r0 r1 r2 r3 r4 r5 r6 r7	r8 r9 r10 r11 r12 r13 r14 r15 r16 r17 r18 r19 r20 r21 r22 r23 r24 r25 r26 r27 r28 r29 r30 r31 ];


### PR DESCRIPTION
This fixes the decoding of 32-bit big-endian MicroBlaze instructions by _removing_ the erroneous `@else # ENDIAN == "big"` instruction definitions and making everything use the little-endian version.

I've only got a 32-bit big-endian MicroBlaze binary to look at (and no toolchains), which I'm pretty confident that it *is* a big-endian binary, based on the ELF headers, pointers, and presence of UTF-32-BE-encoded strings.

The way I evaluated the instruction decoding was to look at the vectors. The manual says:

> Each vector allocates two addresses to allow full address range branching (requires an `IMM` followed by a `BRAI` instruction).

So any of the vectors (at address 0x0, 0x8, 0x10, 0x18, 0x20, 0x28) should contain a 4-byte `IMM` (`0b101100_00000_00000_*` / `0xB000_*`) followed by a 4-byte `BRAI` (`0b101110_00000_01000_*` / `0xB808_*`).

Looking at an `elf32-microblaze` big endian binary, I see:

```
0x0000_0000  B0 00 50 00     imm 0x5000
0x0000_0008  B8 08 00 00     brai 0x0000
```

That would unconditionally jump to address `0x5000_0000`, which matches where the entrypoint of the program is loaded.

This also matches the byte order in the file itself (immediately after the ELF header), so I'm pretty sure there's no other funny business going on.

This was tested with Ghidra 10.4.
